### PR TITLE
Fix recursive in-reformulation (see issue #11)

### DIFF
--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -93,11 +93,13 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
 
   final_batch.add_rule(std::make_shared<LogicalReductionRule>());
 
-  final_batch.add_rule(std::make_shared<ColumnPruningRule>());
-
   final_batch.add_rule(std::make_shared<ExistsReformulationRule>());
 
+  // Relies on being run after LogicalReductionRule (to avoid handling ANDed expressions) and before ColumnPruningRule
+  // (to avoid implementing to much logic when removing projections).
   final_batch.add_rule(std::make_shared<InReformulationRule>());
+
+  final_batch.add_rule(std::make_shared<ColumnPruningRule>());
 
   final_batch.add_rule(std::make_shared<ChunkPruningRule>());
 

--- a/src/lib/optimizer/strategy/in_reformulation_rule.cpp
+++ b/src/lib/optimizer/strategy/in_reformulation_rule.cpp
@@ -274,8 +274,8 @@ bool InReformulationRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node)
   //TODO why is estimate_plan_cost not static?
 
   // Do not reformulate if expected output is small.
-//  if(CostModelLogical().estimate_plan_cost(node) <= Cost{50.0f}){
-  if(node->get_statistics()->row_count() < 150.0f){
+  //  if(CostModelLogical().estimate_plan_cost(node) <= Cost{50.0f}){
+  if (node->get_statistics()->row_count() < 150.0f) {
     return _apply_to_inputs(node);
   }
   std::cout << "node cost before in reformulation: " << CostModelLogical().estimate_plan_cost(node) << '\n';
@@ -292,7 +292,6 @@ bool InReformulationRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node)
 
     return _apply_to_inputs(join_node);
   }
-
 
   // For correlated sub-queries, we use multi-predicate semi/anti joins to join on the in-value and any correlated
   // predicate found in the sub-query.
@@ -344,8 +343,8 @@ bool InReformulationRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node)
   const auto left_columns = predicate_node->left_input()->column_expressions();
   auto distinct_node = AggregateNode::make(left_columns, std::vector<std::shared_ptr<AbstractExpression>>{});
   auto left_only_projection_node = ProjectionNode::make(left_columns);
-  auto join_predicate =
-      std::make_shared<BinaryPredicateExpression>(PredicateCondition::Equals, in_expression->value(), right_join_expression);
+  auto join_predicate = std::make_shared<BinaryPredicateExpression>(PredicateCondition::Equals, in_expression->value(),
+                                                                    right_join_expression);
   const auto join_node = JoinNode::make(JoinMode::Inner, join_predicate);
 
   lqp_replace_node(predicate_node, distinct_node);

--- a/src/lib/optimizer/strategy/in_reformulation_rule.cpp
+++ b/src/lib/optimizer/strategy/in_reformulation_rule.cpp
@@ -311,8 +311,9 @@ bool InReformulationRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node)
   // they use are actually available. We also only pull predicates up over other predicates, projections, sorts and
   // validates (this could probably be extended).
 
-  // NOT IN is not yet supported for correlated queries because an anti join does not preserve the right sub-tree,
-  // which we need to filter. A more complex reformulation could be implemented in the future.
+  // NOT IN is not yet supported for correlated queries there is no good way to emulate multi-predicate anti-joins
+  // using with any other join type, and we cannot use single-predicate an anti-join since it discards the columns of
+  // its right input, which we would need to pull up predicates.
   if (in_expression->is_negated()) {
     return _apply_to_inputs(node);
   }

--- a/src/lib/optimizer/strategy/in_reformulation_rule.cpp
+++ b/src/lib/optimizer/strategy/in_reformulation_rule.cpp
@@ -334,6 +334,15 @@ bool InReformulationRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node)
   const auto& [correlated_predicate_nodes, projection_nodes_to_remove] =
       prepare_predicate_pull_up(right_tree_root, is_correlated_parameter);
 
+  if (contains_unoptimizable_correlated_parameter_usages(right_tree_root, is_correlated_parameter,
+                                                         correlated_predicate_nodes)) {
+    return _apply_to_inputs(node);
+  }
+
+  for (const auto& projection_node : projection_nodes_to_remove) {
+    right_tree_root = remove_from_tree(right_tree_root, projection_node);
+  }
+
   for (const auto& correlated_predicate_node : correlated_predicate_nodes) {
     right_tree_root = remove_from_tree(right_tree_root, correlated_predicate_node);
     patch_correlated_predicate(correlated_predicate_node, correlated_parameters);

--- a/src/test/optimizer/strategy/in_reformulation_rule_test.cpp
+++ b/src/test/optimizer/strategy/in_reformulation_rule_test.cpp
@@ -15,7 +15,6 @@
 #include "optimizer/strategy/in_reformulation_rule.hpp"
 #include "storage/storage_manager.hpp"
 #include "utils/load_table.hpp"
-#include "../../../lib/expression/expression_functional.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 
@@ -65,8 +64,9 @@ class InReformulationRuleTest : public StrategyBaseTest {
   std::shared_ptr<InReformulationRule> _rule;
 
   std::shared_ptr<StoredTableNode> node_table_a, node_table_b, node_table_c, node_table_d, node_table_e;
-  LQPColumnReference node_table_a_col_a, node_table_a_col_b, node_table_b_col_a, node_table_b_col_b, node_table_c_col_a, node_table_c_col_b,
-      node_table_d_col_a, node_table_d_col_b, node_table_d_col_c, node_table_e_col_a, node_table_e_col_b, node_table_e_col_c;
+  LQPColumnReference node_table_a_col_a, node_table_a_col_b, node_table_b_col_a, node_table_b_col_b, node_table_c_col_a,
+      node_table_c_col_b, node_table_d_col_a, node_table_d_col_b, node_table_d_col_c, node_table_e_col_a,
+      node_table_e_col_b, node_table_e_col_c;
 };
 
 TEST_F(InReformulationRuleTest, UncorrelatedInToSemiJoin) {


### PR DESCRIPTION
Fixes #11. The bug was caused by two things:
  * We weren't checking sub-selects for usages of correlated parameters
  * We weren't checking the type of predicates we were pulling up. In particular this meant that we were pulling up (NOT)-IN predicates, causing all kinds of weird behavior.

For now, I've restricted the pulled up predicates to simple comparisons (=,<>,<,<=,>,>=) and also disallowed predicates using sub-selects (so no `correlated_param > (SELECT ...)`). We should revisit this once we know exactly what kinds of predicates the multi-predicate join implementation allows.